### PR TITLE
Add support for zero-based index pagination

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,10 @@
 /*jshint node:true*/
 'use strict';
 
+function isUndefined (value) {
+  return value === void 0;
+}
+
 /**
  * Pagination Class
  * @param {object} options [options object]
@@ -14,7 +18,7 @@ function Pagination (options) {
   this.itemsPerPage = options.itemsPerPage;
 
   // default properties
-  this.firstPage     = options.firstPage || 1;
+  this.firstPage     = isUndefined(options.firstPage) ? 1 : options.firstPage;
   this.rangeLength   = options.rangeLength || 5;
   this.firstLabel    = options.firstLabel || '«';
   this.previousLabel = options.previousLabel || '‹';
@@ -24,7 +28,7 @@ function Pagination (options) {
   // processed properties
   this.offset       = this.getOffset();
   this.totalPages   = this.getTotal();
-  this.lastPage     = this.totalPages;
+  this.lastPage     = this.firstPage + this.totalPages - 1;
   this.nextPage     = this.getNext();
   this.previousPage = this.getPrevious();
   this.rangeStart   = this.getRangeStart();
@@ -41,7 +45,7 @@ Pagination.prototype.validateOptions = function (options) {
     throw new Error('No `options` were passed, aborting.');
   }
 
-  if (!options.currentPage || !options.totalItems || !options.itemsPerPage) {
+  if (isUndefined(options.currentPage) || !options.totalItems || !options.itemsPerPage) {
     throw new Error('You must define your options object correctly, aborting.');
   }
 
@@ -72,7 +76,7 @@ Pagination.prototype.getTotal = function () {
  */
 Pagination.prototype.getNext = function () {
   var next = this.currentPage + 1;
-  return next > this.totalPages ? null : next;
+  return next > this.lastPage ? null : next;
 };
 
 /**
@@ -81,7 +85,7 @@ Pagination.prototype.getNext = function () {
  */
 Pagination.prototype.getPrevious = function () {
   var previous = this.currentPage - 1;
-  return previous < 1 ? null : previous;
+  return previous < this.firstPage ? null : previous;
 };
 
 /**
@@ -126,7 +130,7 @@ Pagination.prototype.getRange = function () {
     range.push({ page : this.firstPage, isFirst : true, label : this.firstLabel });
   }
 
-  if (this.previousPage) {
+  if (this.previousPage !== null) {
     range.push({ page : this.previousPage, isPrevious : true, label : this.previousLabel });
   }
 

--- a/test/test.js
+++ b/test/test.js
@@ -21,6 +21,33 @@ describe('Pagination Object Tests', function () {
     }); }, Error);
   });
 
+  it('should have expected defaults', function () {
+    var pagination = new Pagination({
+      currentPage  : 1,
+      totalItems   : 11,
+      itemsPerPage : 10
+    });
+
+    assert.equal(pagination.firstPage, 1);
+    assert.equal(pagination.rangeLength, 5);
+    assert.equal(pagination.firstLabel, '«');
+    assert.equal(pagination.previousLabel, '‹');
+    assert.equal(pagination.nextLabel, '›');
+    assert.equal(pagination.lastLabel, '»');
+  });
+
+  it('should support zero-based pagination', function () {
+    var pagination = new Pagination({
+      currentPage  : 0,
+      totalItems   : 31,
+      itemsPerPage : 10,
+      firstPage    : 0
+    });
+
+    assert.equal(pagination.currentPage, 0);
+    assert.equal(pagination.firstPage, 0);
+  });
+
   it('next page should be 3', function () {
     var pagination = new Pagination({
       currentPage  : 1,
@@ -41,6 +68,17 @@ describe('Pagination Object Tests', function () {
     assert.equal(pagination.nextPage, null);
   });
 
+  it('next page should be null (last page, firstPage 0)', function () {
+    var pagination = new Pagination({
+      currentPage  : 2,
+      totalItems   : 30,
+      itemsPerPage : 10,
+      firstPage    : 0
+    });
+
+    assert.equal(pagination.nextPage, null);
+  });
+
   it('previous page should be 1', function () {
     var pagination = new Pagination({
       currentPage  : 2,
@@ -49,6 +87,17 @@ describe('Pagination Object Tests', function () {
     });
 
     assert.equal(pagination.previousPage, 1);
+  });
+
+  it('previous page should be 0 (firstPage 0)', function () {
+    var pagination = new Pagination({
+      currentPage  : 1,
+      totalItems   : 30,
+      itemsPerPage : 10,
+      firstPage    : 0
+    });
+
+    assert.equal(pagination.previousPage, 0);
   });
 
   it('previous page should be null (first page)', function () {
@@ -79,6 +128,28 @@ describe('Pagination Object Tests', function () {
     });
 
     assert.equal(pagination.totalPages, 1);
+  });
+
+  it('last page should be 3 (firstPage 1)', function () {
+    var pagination = new Pagination({
+      currentPage  : 1,
+      totalItems   : 30,
+      itemsPerPage : 10,
+      firstPage    : 1
+    });
+
+    assert.equal(pagination.lastPage, 3);
+  });
+
+  it('last page should be 2 (firstPage 0)', function () {
+    var pagination = new Pagination({
+      currentPage  : 1,
+      totalItems   : 30,
+      itemsPerPage : 10,
+      firstPage    : 0
+    });
+
+    assert.equal(pagination.lastPage, 2);
   });
 
   it('offset should be 2', function () {
@@ -295,6 +366,25 @@ describe('Pagination Object Tests', function () {
       { page : 4 },
       { page : 5 },
       { page : 6, isCurrent : true }
+    ]);
+  });
+
+  it('range should be equal to array', function () {
+    var pagination = new Pagination({
+      currentPage  : 1,
+      totalItems   : 30,
+      itemsPerPage : 10,
+      firstPage    : 0
+    });
+
+    assert.deepEqual(pagination.range, [
+      { page : 0, isFirst : true, label : '«' },
+      { page : 0, isPrevious : true, label : '‹' },
+      { page : 0 },
+      { page : 1, isCurrent : true },
+      { page : 2 },
+      { page : 2, isNext : true, label : '›' },
+      { page : 2, isLast : true, label : '»' }
     ]);
   });
 


### PR DESCRIPTION
Allow `currentPage` and `firstPage` to accept `0` as a possible
value, and update `lastPage`, `nextPage`, and `previousPage`
calculations to take zero-based index pagination into account.
