### PR TITLE
allow range to be limited

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,11 @@ Default: `1`
 Type: `Number`
 Default: `5`
 
+### rangeLimit
+
+Type: `Boolean`
+Default: `false`
+
 ### firstLabel
 
 Type: `String`

--- a/index.js
+++ b/index.js
@@ -20,6 +20,7 @@ function Pagination (options) {
   // default properties
   this.firstPage     = isUndefined(options.firstPage) ? 1 : options.firstPage;
   this.rangeLength   = options.rangeLength || 5;
+  this.rangeLimit    = options.rangeLimit || false;
   this.firstLabel    = options.firstLabel || '«';
   this.previousLabel = options.previousLabel || '‹';
   this.nextLabel     = options.nextLabel || '›';
@@ -112,7 +113,10 @@ Pagination.prototype.getRangeEnd = function () {
   rangeEnd = this.currentPage + this.offset;
   rangeEnd = rangeEnd < this.rangeLength ? this.rangeLength : rangeEnd;
   rangeEnd = rangeEnd > this.lastPage ? this.lastPage : rangeEnd;
-  diff     = this.totalPages - rangeEnd - this.offset;
+
+  if (!this.rangeLimit) {
+    diff = this.totalPages - rangeEnd - this.offset;
+  }
 
   return diff > 0 ? rangeEnd + diff : rangeEnd;
 };

--- a/test/test.js
+++ b/test/test.js
@@ -388,6 +388,26 @@ describe('Pagination Object Tests', function () {
     ]);
   });
 
+  it('range should be limited when rangeLimit = true', function () {
+    var pagination = new Pagination({
+      currentPage  : 1,
+      totalItems   : 100,
+      itemsPerPage : 10,
+      rangeEnd     : 5,
+      rangeLimit   : true
+    });
+
+    assert.deepEqual(pagination.range, [
+      { page : 1, isCurrent : true },
+      { page : 2 },
+      { page : 3 },
+      { page : 4 },
+      { page : 5 },
+      { page : 2, isNext : true, label : '›' },
+      { page : 10, isLast : true, label : '»' }
+    ]);
+  });
+
   it('labels should be changeable', function () {
     var pagination = new Pagination({
       currentPage   : 4,


### PR DESCRIPTION
Hi, I would like to only show a certain amount of pagination results at a certain time, but this doesn't seem possible for lists with large amounts of results.

The following https://github.com/renancouto/pagination-object/blob/master/index.js#L115 always adds the remaining pagination links to the `range` array, even if I set a `rangeEnd`.

I've added in a `rangeLimit` boolean option that will allow you to always show only the `rangeEnd` number of links.
